### PR TITLE
use tag as application version

### DIFF
--- a/src/jch.app.src
+++ b/src/jch.app.src
@@ -27,7 +27,7 @@
 {application, jch,
  [
   {description, "A Jump Consistent Hash library"},
-  {vsn, "0.1.0"},
+  {vsn, git},
   {modules, [ jch ]},
   {registered, []},
   {applications, [ kernel, stdlib ]},


### PR DESCRIPTION
I noticed you tagged 0.2.2 but the version in `.app.src` is `0.1.0`. This PR replaces the static version with `git` which tells rebar3 to replace it with the latest tag, if it isn't on an exact tag it'll use a version of the latest tag `+build.#.ref<git hash>`.